### PR TITLE
fix: support for windows, custom delimiter

### DIFF
--- a/scripts/tools/copyPackageSet.ts
+++ b/scripts/tools/copyPackageSet.ts
@@ -11,9 +11,9 @@ export const copyPackageSet = async (): Promise<void> => {
   const libDir = "lib";
   const publishPackageJson = path.join(libDir, "package.json");
   pkg.private = undefined;
-  pkg.main = path.relative(libDir, pkg.main);
-  pkg.module = path.relative(libDir, pkg.module);
-  pkg.types = path.relative(libDir, pkg.types);
+  pkg.main = path.posix.relative(libDir, pkg.main);
+  pkg.module = path.posix.relative(libDir, pkg.module);
+  pkg.types = path.posix.relative(libDir, pkg.types);
   pkg.directories = undefined;
   pkg.files = undefined;
   fs.writeFileSync(publishPackageJson, JSON.stringify(pkg, null, 2), {

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,9 +1,20 @@
-import { normalize } from "path";
-
 export const generateKey = (kind: string, name: string): string => {
   return `${kind}:${name}`;
 };
 
 export const split = (p: string, delimiter: string): string[] => {
-  return normalize(p).split(delimiter);
+  const array = [];
+  for (const seg of p.split(delimiter)) {
+    switch (seg) {
+      case ".":
+        break;
+      case "..":
+        array.pop();
+        break;
+      default:
+        array.push(seg);
+        break;
+    }
+  }
+  return array;
 };


### PR DESCRIPTION
The `split` function does not respect the delimiter parameter. It will not work if `path.sep` and `delimiter` are different.